### PR TITLE
feature(hansbug): Add __version__ to treevalue module

### DIFF
--- a/treevalue/__init__.py
+++ b/treevalue/__init__.py
@@ -1,1 +1,3 @@
+# noinspection PyPep8Naming
+from .config.meta import __VERSION__ as __version__
 from .tree import *


### PR DESCRIPTION
## Description

Add `__version__` for treevalue module, make the version information accessible like this

```python
from treevalue import __version__

print(__version__)
```

## Related Issue

#6 

## TODO

(nothing...

## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [x] pass all the tests


