### PR TITLE
fix(hansbug): fix bug when missing is used on the whole non-existing child tree

### DIFF
--- a/test/tree/func/test_func.py
+++ b/test/tree/func/test_func.py
@@ -217,3 +217,43 @@ class TestTreeFuncFunc:
                 return x + y
 
         assert MyTreeValue.plus(TreeValue({'a': 1, 'b': 2}), 2) == MyTreeValue({'a': 3, 'b': 4})
+
+    def test_missing(self):
+        @func_treelize(mode='outer', missing=lambda: [])
+        def append(arr: list, *args):
+            for item in args:
+                if item:
+                    arr.append(item)
+            return arr
+
+        t0 = TreeValue({})
+        t1 = TreeValue({'a': 2, 'b': 7, 'x': {'c': 4, 'd': 9}})
+        t2 = TreeValue({'a': 4, 'b': 48, 'x': {'c': -11, 'd': 54}})
+        t3 = TreeValue({'a': 9, 'b': -12, 'x': {'c': 3, 'd': 4}})
+
+        assert append(t0, t1, t2, t3) == TreeValue({
+            'a': [2, 4, 9],
+            'b': [7, 48, -12],
+            'x': {
+                'c': [4, -11, 3],
+                'd': [9, 54, 4],
+            }
+        })
+
+        t0 = TreeValue({})
+        t1 = TreeValue({'a': 2, 'x': {'c': 4, 'd': 9}})
+        t2 = TreeValue({'a': 4, 'b': 48, 'x': {'d': 54}})
+        t3 = TreeValue({'b': -12, 'x': 7, 'y': {'e': 3, 'f': 4}})
+
+        assert append(t0, t1, t2, t3) == TreeValue({
+            'a': [2, 4],
+            'b': [48, -12],
+            'x': {
+                'c': [4, 7],
+                'd': [9, 54, 7],
+            },
+            'y': {
+                'e': [3],
+                'f': [4],
+            },
+        })


### PR DESCRIPTION
## Description

Fix bug of `missing` option.

## Related Issue

#10 

## TODO

Waiting for a code review.

## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [x] pass all the tests
