### PR TITLE
dev(hansbug): add get_or_default method to test_storage

### DIFF
--- a/docs/source/api_doc/tree/tree.rst
+++ b/docs/source/api_doc/tree/tree.rst
@@ -9,7 +9,7 @@ TreeValue
 ---------------
 
 .. autoclass:: TreeValue
-    :members: __init__, __getattr__, __setattr__, __delattr__, __contains__, __repr__, __iter__, __hash__, __eq__, _attr_extern, __len__, __bool__, __str__, __getstate__, __setstate__
+    :members: __init__, __getattr__, __setattr__, __delattr__, __contains__, __repr__, __iter__, __hash__, __eq__, _attr_extern, __len__, __bool__, __str__, __getstate__, __setstate__, get
 
 
 .. _apidoc_tree_tree_jsonify:

--- a/test/tree/common/test_storage.py
+++ b/test/tree/common/test_storage.py
@@ -23,6 +23,17 @@ class TestTreeStorage:
         with pytest.raises(KeyError):
             _ = t.get('fff')
 
+    def test_get_or_default(self):
+        t = create_storage({'a': 1, 'b': 2, 'c': raw({'x': 3, 'y': 4}), 'd': {'x': 3, 'y': 4}})
+        assert t.get_or_default('a', 233) == 1
+        assert t.get_or_default('b', 233) == 2
+        assert t.get_or_default('c', 233) == {'x': 3, 'y': 4}
+        assert isinstance(t.get_or_default('d', 233), TreeStorage)
+        assert t.get_or_default('d', 233).get_or_default('x', 233) == 3
+        assert t.get_or_default('d', 233).get_or_default('y', 233) == 4
+
+        assert t.get_or_default('fff', 233) == 233
+
     def test_set(self):
         t = create_storage({})
         t.set('a', 1)

--- a/test/tree/tree/test_tree.py
+++ b/test/tree/tree/test_tree.py
@@ -3,7 +3,7 @@ import re
 
 import pytest
 
-from treevalue.tree.tree import TreeValue
+from treevalue import raw, TreeValue
 
 
 class _Container:
@@ -179,3 +179,14 @@ class TestTreeTreeTree:
         })
         bt2 = pickle.dumps(tv2)
         assert pickle.loads(bt2) == tv2
+
+    def test_get(self):
+        tv1 = TreeValue({'a': 1, 'b': 2, 'c': {'x': 2, 'y': 3}, 'd': raw({'x': 2, 'y': 3})})
+
+        assert tv1.get('a') == 1
+        assert tv1.get('b') == 2
+        assert tv1.get('c') == TreeValue({'x': 2, 'y': 3})
+        assert tv1.get('d') == {'x': 2, 'y': 3}
+        with pytest.raises(KeyError):
+            _ = tv1.get('e')
+        assert tv1.get('e', 233) == 233

--- a/treevalue/tree/common/storage.pxd
+++ b/treevalue/tree/common/storage.pxd
@@ -11,6 +11,7 @@ cdef class TreeStorage:
 
     cpdef public void set(self, str key, object value) except *
     cpdef public object get(self, str key)
+    cpdef public object get_or_default(self, str key, object default)
     cpdef public void del_(self, str key) except *
     cpdef public boolean contains(self, str key)
     cpdef public uint size(self)

--- a/treevalue/tree/common/storage.pyx
+++ b/treevalue/tree/common/storage.pyx
@@ -40,6 +40,9 @@ cdef class TreeStorage:
         except KeyError:
             raise KeyError(f"Key {repr(key)} not found in this tree.")
 
+    cpdef public object get_or_default(self, str key, object default):
+        return self.map.get(key, default)
+
     cpdef public void del_(self, str key) except *:
         try:
             del self.map[key]

--- a/treevalue/tree/tree/tree.pxd
+++ b/treevalue/tree/tree/tree.pxd
@@ -11,6 +11,7 @@ cdef class TreeValue:
     cdef object _unraw(self, object obj)
     cdef object _raw(self, object obj)
     cpdef _attr_extern(self, str key)
+    cpdef get(self, str key, object default= *)
 
 cdef str _prefix_fix(object text, object prefix)
 cdef object _build_tree(TreeStorage st, object type_, str prefix, dict id_pool, tuple path)


### PR DESCRIPTION
## Description

Make the `TreeValue` class support the `getdefault` method, such as `xxx.get('xxx', 233)`

## Related Issue

Nothing yet

## TODO

Keep on developing

## Check List

- [x] merge the latest version source branch/repo, and resolve all the conflicts
- [x] pass style check
- [x] pass all the tests
