### PR TITLE
dev(hansbug): fix support of rise and subside for namedtuple

### DIFF
--- a/test/tree/tree/test_structural.py
+++ b/test/tree/tree/test_structural.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 import pytest
 
 from treevalue.tree import TreeValue, mapping, union, raw, subside, rise, delayed
@@ -115,6 +117,18 @@ class TestTreeTreeStructural:
 
         assert subside({'a': 1, 'b': 2, 'x': {'c': 3, 'd': 4}, 'e': [3, 4, 5]}) == \
                {'a': 1, 'b': 2, 'x': {'c': 3, 'd': 4}, 'e': [3, 4, 5]}
+
+        nt = namedtuple('nt', ['a', 'b', 'c'])
+        a = nt(
+            MyTreeValue({'x': 1, 'y': 2, 'z': {'v': 3}}),
+            MyTreeValue({'x': 4, 'y': 5, 'z': {'v': 6}}),
+            MyTreeValue({'x': 7, 'y': 8, 'z': {'v': 9}}),
+        )
+        assert subside(a) == MyTreeValue({
+            'x': nt(1, 4, 7),
+            'y': nt(2, 5, 8),
+            'z': {'v': nt(3, 6, 9), },
+        })
 
     def test_subside_delayed(self):
         class MyTreeValue(TreeValue):
@@ -273,3 +287,15 @@ class TestTreeTreeStructural:
                 MyTreeValue({'v': {'x': 3, 'y': 8}}),
             ]
         }
+
+        nt = namedtuple('nt', ['a', 'b', 'c'])
+        t11 = MyTreeValue({
+            'x': nt(1, 4, 7),
+            'y': nt(2, 5, 8),
+            'z': {'v': nt(3, 6, 9), },
+        })
+        assert rise(t11) == nt(
+            MyTreeValue({'x': 1, 'y': 2, 'z': {'v': 3}}),
+            MyTreeValue({'x': 4, 'y': 5, 'z': {'v': 6}}),
+            MyTreeValue({'x': 7, 'y': 8, 'z': {'v': 9}}),
+        )

--- a/test/tree/tree/test_structural.py
+++ b/test/tree/tree/test_structural.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 import pytest
 
+from treevalue import FastTreeValue
 from treevalue.tree import TreeValue, mapping, union, raw, subside, rise, delayed
 
 
@@ -124,11 +125,17 @@ class TestTreeTreeStructural:
             MyTreeValue({'x': 4, 'y': 5, 'z': {'v': 6}}),
             MyTreeValue({'x': 7, 'y': 8, 'z': {'v': 9}}),
         )
-        assert subside(a) == MyTreeValue({
+        t5 = subside(a)
+        assert t5 == MyTreeValue({
             'x': nt(1, 4, 7),
             'y': nt(2, 5, 8),
             'z': {'v': nt(3, 6, 9), },
         })
+
+        t6 = subside(a, return_type=FastTreeValue)
+        assert t6.a == FastTreeValue({'x': 1, 'y': 2, 'z': {'v': 3}})
+        assert t6.b == FastTreeValue({'x': 4, 'y': 5, 'z': {'v': 6}})
+        assert t6.c == FastTreeValue({'x': 7, 'y': 8, 'z': {'v': 9}})
 
     def test_subside_delayed(self):
         class MyTreeValue(TreeValue):


### PR DESCRIPTION
```python
from collections import namedtuple

from treevalue import FastTreeValue, subside, rise

nt = namedtuple('nt', ['a', 'b', 'c'])

if __name__ == '__main__':
    a = nt(
        FastTreeValue({'x': 1, 'y': 2, 'z': {'v': 3}}),
        FastTreeValue({'x': 4, 'y': 5, 'z': {'v': 6}}),
        FastTreeValue({'x': 7, 'y': 8, 'z': {'v': 9}}),
    )
    t = subside(a)
    print(t)

    origin = rise(t)
    print(origin)
```

The output should be

```python
<FastTreeValue 0x7f612b92fc90>
├── 'x' --> nt(a=1, b=4, c=7)
├── 'y' --> nt(a=2, b=5, c=8)
└── 'z' --> <FastTreeValue 0x7f612b92fe50>
    └── 'v' --> nt(a=3, b=6, c=9)

nt(a=<FastTreeValue 0x7f612b92fdd0>
├── 'x' --> 1
├── 'y' --> 2
└── 'z' --> <FastTreeValue 0x7f612b92fd10>
    └── 'v' --> 3
, b=<FastTreeValue 0x7f612b92fa50>
├── 'x' --> 4
├── 'y' --> 5
└── 'z' --> <FastTreeValue 0x7f612b92f9d0>
    └── 'v' --> 6
, c=<FastTreeValue 0x7f612b92f910>
├── 'x' --> 7
├── 'y' --> 8
└── 'z' --> <FastTreeValue 0x7f612b92f890>
    └── 'v' --> 9
)
```