### PR TITLE
dev(hansbug): test for torch high version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,12 @@ jobs:
         exclude:
           - python-version: '3.7'
             torch-version: '2.0.1'
+          - python-version: '3.10'
+            torch-version: '1.7.1'
+          - python-version: '3.11'
+            torch-version: '1.7.1'
+          - python-version: '3.11'
+            torch-version: '1.13.1'
 
     steps:
       - name: Get system version for Linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
           - '1.13.1'
           - '2.0.1'
           - 'latest'
+        exclude:
+          - python-version: '3.7'
+            torch-version: '2.0.1'
 
     steps:
       - name: Get system version for Linux
@@ -99,16 +102,15 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-build.txt
           pip install -r requirements-test.txt
-      - name: Install Torch
-        shell: bash
-        if: ${{ matrix.torch-version != 'latest' }}
-        continue-on-error: true
-        run: |
-          pip install torch==${{ matrix.torch-version }}
       - name: Install Extra Test Requirements
         shell: bash
         run: |
           pip install -r requirements-test-extra.txt
+      - name: Install Torch
+        shell: bash
+        if: ${{ matrix.torch-version != 'latest' }}
+        run: |
+          pip install torch==${{ matrix.torch-version }}
       - name: Test the basic environment
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         torch-version:
           - '1.7.1'
           - '1.13.1'
+          - '2.0.1'
           - 'latest'
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1214,3 +1214,4 @@ fabric.properties
 !/runs/artifacts
 /runs/artifacts/*
 .benchmarks
+/venv*

--- a/requirements-test-extra.txt
+++ b/requirements-test-extra.txt
@@ -1,2 +1,2 @@
 jax[cpu]>=0.3.25; platform_system != 'Windows'
-torch>=1.1.0; python_version < '3.11'
+torch>=1.1.0; python_version < '3.12'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ enum_tools
 graphviz~=0.17
 dill~=0.3.4
 click>=7.1.0
-hbutils>=0.0.1
+hbutils>=0.9.1

--- a/test/tree/tree/base.py
+++ b/test/tree/tree/base.py
@@ -770,7 +770,7 @@ def get_treevalue_test(treevalue_class: Type[TreeValue]):
             _repr_png_ = t1._repr_png_()
             assert isinstance(_repr_png_, bytes)
             if OS.windows:
-                min_size, max_size = 12000, 16050
+                min_size, max_size = 14000, 18050
             else:
                 min_size, max_size = 16050, 20500
             assert min_size <= len(_repr_png_) <= max_size, \

--- a/test/tree/tree/base.py
+++ b/test/tree/tree/base.py
@@ -758,7 +758,9 @@ def get_treevalue_test(treevalue_class: Type[TreeValue]):
 
             _repr_svg_ = t1._repr_svg_()
             assert isinstance(_repr_svg_, str)
-            assert 4500 <= len(_repr_svg_) <= 4900
+            min_size, max_size = 4500, 4900
+            assert min_size <= len(_repr_svg_) <= max_size, \
+                f'Size within [{min_size!r}, {max_size!r}] required, but {len(_repr_svg_)!r} found.'
 
         @unittest.skipUnless(cmdv('dot'), 'Dot installed only')
         def test_repr_png(self):
@@ -768,9 +770,11 @@ def get_treevalue_test(treevalue_class: Type[TreeValue]):
             _repr_png_ = t1._repr_png_()
             assert isinstance(_repr_png_, bytes)
             if OS.windows:
-                assert 12000 <= len(_repr_png_) <= 16050
+                min_size, max_size = 12000, 16050
             else:
-                assert 16050 <= len(_repr_png_) <= 20500
+                min_size, max_size = 16050, 20500
+            assert min_size <= len(_repr_png_) <= max_size, \
+                f'Size within [{min_size!r}, {max_size!r}] required, but {len(_repr_png_)!r} found.'
 
         @unittest.skipUnless(cmdv('dot'), 'Dot installed only')
         def test_repr_jpeg(self):
@@ -779,6 +783,8 @@ def get_treevalue_test(treevalue_class: Type[TreeValue]):
 
             _repr_jpeg_ = t1._repr_jpeg_()
             assert isinstance(_repr_jpeg_, bytes)
-            assert 10500 <= len(_repr_jpeg_) <= 14500
+            min_size, max_size = 10500, 14500
+            assert min_size <= len(_repr_jpeg_) <= max_size, \
+                f'Size within [{min_size!r}, {max_size!r}] required, but {len(_repr_jpeg_)!r} found.'
 
     return _TestClass


### PR DESCRIPTION
Add torch's support for higher version

Attention that the `torch.compile` in torch2 is not supported now due to the issue https://github.com/pytorch/pytorch/issues/99262, maybe it will be supported when next torch2 version is released.