### PR TITLE
dev(hansbug): add register custom dicts

### DIFF
--- a/docs/source/api_doc/tree/tree.rst
+++ b/docs/source/api_doc/tree/tree.rst
@@ -220,3 +220,11 @@ loads
 
 .. autofunction:: loads
 
+
+register_dict_type
+----------------------------
+
+.. autofunction:: register_dict_type
+
+
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-timeout = 20
+timeout = 60
 markers =
     unittest
     benchmark

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,7 +1,7 @@
 Jinja2~=3.0.0
 sphinx~=3.2.0
 sphinx_rtd_theme~=0.4.3
-enum_tools
+enum_tools~=0.9.0
 sphinx-toolbox
 plantumlcli>=0.0.4
 packaging

--- a/requirements-test-extra.txt
+++ b/requirements-test-extra.txt
@@ -1,2 +1,2 @@
 jax[cpu]>=0.3.25; platform_system != 'Windows'
-torch>=1.1.0; python_version < '3.12'
+torch>=1.1.0,<2.1.0; python_version < '3.12'

--- a/test/testings/__init__.py
+++ b/test/testings/__init__.py
@@ -1,0 +1,1 @@
+from .mapping import CustomMapping

--- a/test/testings/mapping.py
+++ b/test/testings/mapping.py
@@ -1,0 +1,15 @@
+import collections.abc
+
+
+class CustomMapping(collections.abc.Mapping):
+    def __init__(self, **kwargs):
+        self._kwargs = kwargs
+
+    def __getitem__(self, __key):
+        return self._kwargs[__key]
+
+    def __len__(self):
+        return len(self._kwargs)
+
+    def __iter__(self):
+        yield from self._kwargs

--- a/test/tree/general/base.py
+++ b/test/tree/general/base.py
@@ -11,20 +11,8 @@ from hbutils.testing import cmdv
 from treevalue import register_dict_type
 from treevalue.tree import func_treelize, TreeValue, raw, mapping, delayed, FastTreeValue
 from ..tree.base import get_treevalue_test
+from ...testings import CustomMapping
 
-
-class CustomMapping(collections.abc.Mapping):
-    def __init__(self, **kwargs):
-        self._kwargs = kwargs
-
-    def __getitem__(self, __key):
-        return self._kwargs[__key]
-
-    def __len__(self):
-        return len(self._kwargs)
-
-    def __iter__(self):
-        yield from self._kwargs
 
 
 def get_fasttreevalue_test(treevalue_class: Type[FastTreeValue]):

--- a/test/tree/integration/test_torch.py
+++ b/test/tree/integration/test_torch.py
@@ -161,3 +161,20 @@ class TestTreeIntegrationTorch:
             'c': torch.Size([14]),
             'd': torch.Size([2, 5, 3]),
         })
+
+    @skipUnless(vpip('torch') and OS.linux and vpython < '3.11', 'torch required')
+    def test_moduledict(self):
+        with torch.no_grad():
+            md = torch.nn.ModuleDict({
+                'a': torch.nn.Linear(3, 5),
+                'b': torch.nn.Linear(3, 6),
+            })
+            t = FastTreeValue(md)
+
+            input_ = torch.randn(2, 3)
+            output_ = t(input_)
+
+            assert output_.shape == FastTreeValue({
+                'a': (2, 5),
+                'b': (2, 6),
+            })

--- a/test/tree/integration/test_torch.py
+++ b/test/tree/integration/test_torch.py
@@ -162,7 +162,7 @@ class TestTreeIntegrationTorch:
             'd': torch.Size([2, 5, 3]),
         })
 
-    @skipUnless(vpip('torch') and OS.linux and vpython < '3.11', 'torch required')
+    @skipUnless(torch is not None and vpip('torch') and OS.linux and vpython < '3.11', 'torch required')
     def test_moduledict(self):
         with torch.no_grad():
             md = torch.nn.ModuleDict({

--- a/test/tree/tree/base.py
+++ b/test/tree/tree/base.py
@@ -1,4 +1,3 @@
-import collections.abc
 import pickle
 import re
 import unittest
@@ -11,6 +10,7 @@ from test.tree.tree.test_constraint import GreaterThanConstraint
 from treevalue import raw, TreeValue, delayed, ValidationError, register_dict_type
 from treevalue.tree.common import create_storage
 from treevalue.tree.tree.constraint import cleaf
+from ...testings import CustomMapping
 
 try:
     _ = reversed({}.keys())
@@ -42,20 +42,6 @@ class _Container:
 
     def __hash__(self):
         return hash((self.__value,))
-
-
-class CustomMapping(collections.abc.Mapping):
-    def __init__(self, **kwargs):
-        self._kwargs = kwargs
-
-    def __getitem__(self, __key):
-        return self._kwargs[__key]
-
-    def __len__(self):
-        return len(self._kwargs)
-
-    def __iter__(self):
-        yield from self._kwargs
 
 
 def get_treevalue_test(treevalue_class: Type[TreeValue]):

--- a/treevalue/tree/integration/jax.py
+++ b/treevalue/tree/integration/jax.py
@@ -1,6 +1,8 @@
 import warnings
 from functools import wraps
 
+from ..tree import register_dict_type
+
 try:
     import jax
     from jax.tree_util import register_pytree_node
@@ -20,3 +22,10 @@ else:
 
     register_for_jax(TreeValue)
     register_for_jax(FastTreeValue)
+
+try:
+    from torch.nn import ModuleDict
+except (ModuleNotFoundError, ImportError):
+    pass
+else:
+    register_dict_type(ModuleDict, ModuleDict.items)

--- a/treevalue/tree/integration/jax.py
+++ b/treevalue/tree/integration/jax.py
@@ -1,8 +1,6 @@
 import warnings
 from functools import wraps
 
-from ..tree import register_dict_type
-
 try:
     import jax
     from jax.tree_util import register_pytree_node
@@ -22,10 +20,3 @@ else:
 
     register_for_jax(TreeValue)
     register_for_jax(FastTreeValue)
-
-try:
-    from torch.nn import ModuleDict
-except (ModuleNotFoundError, ImportError):
-    pass
-else:
-    register_dict_type(ModuleDict, ModuleDict.items)

--- a/treevalue/tree/integration/torch.py
+++ b/treevalue/tree/integration/torch.py
@@ -1,6 +1,8 @@
 import warnings
 from functools import wraps
 
+from ..tree import register_dict_type
+
 try:
     import torch
     from torch.utils._pytree import _register_pytree_node
@@ -20,3 +22,10 @@ else:
 
     register_for_torch(TreeValue)
     register_for_torch(FastTreeValue)
+
+try:
+    from torch.nn import ModuleDict
+except (ModuleNotFoundError, ImportError):
+    pass
+else:
+    register_dict_type(ModuleDict, ModuleDict.items)

--- a/treevalue/tree/tree/__init__.py
+++ b/treevalue/tree/tree/__init__.py
@@ -5,4 +5,4 @@ from .graph import graphics
 from .io import loads, load, dumps, dump
 from .service import jsonify, clone, typetrans, walk
 from .structural import subside, union, rise
-from .tree import TreeValue, delayed, ValidationError
+from .tree import TreeValue, delayed, ValidationError, register_dict_type

--- a/treevalue/tree/tree/tree.pxd
+++ b/treevalue/tree/tree/tree.pxd
@@ -14,6 +14,7 @@ cdef class _SimplifiedConstraintProxy:
     cdef readonly Constraint cons
 
 cdef Constraint _c_get_constraint(object cons)
+cpdef register_dict_type(object type_, object f_items)
 
 cdef class ValidationError(Exception):
     cdef readonly TreeValue _object

--- a/treevalue/tree/tree/tree.pyx
+++ b/treevalue/tree/tree/tree.pyx
@@ -35,7 +35,19 @@ _KNOWN_DICT_TYPES = {
     Mapping: Mapping.items,
 }
 
+@cython.binding(True)
 cpdef inline register_dict_type(object type_, object f_items):
+    """
+    Overview:
+        Register dict-like type for TreeValue.
+
+    :param type_: Type to register.
+    :param f_items: Function to get items, the format should be like ``dict.items``.
+
+    .. note::
+        If torch detected, the ``torch.nn.ModuleDict`` is registered by default.
+
+    """
     if isinstance(object, type):
         _KNOWN_DICT_TYPES[type_] = f_items
     else:

--- a/treevalue/tree/tree/tree.pyx
+++ b/treevalue/tree/tree/tree.pyx
@@ -31,23 +31,46 @@ cdef inline object _item_unwrap(object v):
         return v
 
 _GET_NO_DEFAULT = SingletonMark('get_no_default')
+_KNOWN_DICT_TYPES = {
+    Mapping: Mapping.items,
+}
 
-cdef inline TreeStorage _dict_unpack(dict d):
+cpdef inline register_dict_type(object type_, object f_items):
+    if isinstance(object, type):
+        _KNOWN_DICT_TYPES[type_] = f_items
+    else:
+        raise TypeError(f'Not a type - {type_!r}.')
+
+_DEFAULT_STORAGE = create_storage({})
+
+cdef inline TreeStorage _generic_dict_unpack(object d):
     cdef str k
     cdef object v
     cdef dict result = {}
 
-    for k, v in d.items():
+    cdef object d_items = None
+    if isinstance(d, dict):
+        d_items = d.items()
+    else:
+        for d_type, df_items in _KNOWN_DICT_TYPES.items():
+            if isinstance(d, d_type):
+                d_items = df_items(d)
+                break
+        if d_items is None:
+            raise TypeError(f'Unknown dict type - {d!r}.')
+
+    for k, v in d_items:
         if isinstance(v, dict):
-            result[k] = _dict_unpack(v)
-        elif isinstance(v, TreeValue):
+            result[k] = _generic_dict_unpack(v)
+        if isinstance(v, TreeValue):
             result[k] = v._detach()
         else:
-            result[k] = v
+            try:
+                result[k] = _generic_dict_unpack(v)
+            except TypeError:
+                result[k] = v
 
     return create_storage(result)
-
-_DEFAULT_STORAGE = create_storage({})
 
 cdef class _SimplifiedConstraintProxy:
     def __cinit__(self, Constraint cons):
@@ -131,13 +154,14 @@ cdef class TreeValue:
                 self._child_constraints = data._child_constraints
             else:
                 self.constraint = _c_get_constraint(constraint)
-        elif isinstance(data, dict):
-            self._st = _dict_unpack(data)
-            self.constraint = _c_get_constraint(constraint)
         else:
-            raise TypeError(
-                "Unknown initialization type for tree value - {type}.".format(
-                    type=repr(type(data).__name__)))
+            try:
+                self._st = _generic_dict_unpack(data)
+                self.constraint = _c_get_constraint(constraint)
+            except TypeError:
+                raise TypeError(
+                    "Unknown initialization type for tree value - {type}.".format(
+                        type=repr(type(data).__name__)))
 
     def __getnewargs_ex__(self):  # for __cinit__, when pickle.loads
         return ({},), {}


### PR DESCRIPTION
## Description

```python
import torch.nn

from treevalue import FastTreeValue


class MyModule(torch.nn.Module):
    def __init__(self, p):
        torch.nn.Module.__init__(self)
        self.relu = torch.nn.ReLU()
        self.p = torch.tensor(p)

    def forward(self, x):
        return self.relu(x + self.p)


class FullModule(torch.nn.Module):
    def __init__(self, **kwargs):
        torch.nn.Module.__init__(self)
        self._module_dict = torch.nn.ModuleDict({
            key: MyModule(value)
            for key, value in kwargs.items()
        })
        self._module_tv = FastTreeValue(self._module_dict)

    def forward(self, x):
        return self._module_tv(x)


model = FullModule(a=1, b=2)
print(model)

input_ = FastTreeValue({
    'a': torch.randn(3, 4),
    'b': torch.randn(2, 3),
})
print(model(input_))

```

## TODO

* [ ] Try to reduce the lines of ModuleDict&TreeValue usage

## Check List

- [ ] merge the latest version source branch/repo, and resolve all the conflicts
- [ ] pass style check
- [ ] pass all the tests
